### PR TITLE
Clean Up API Response

### DIFF
--- a/integrand-py/tests/test_integrand.py
+++ b/integrand-py/tests/test_integrand.py
@@ -155,7 +155,7 @@ class TestMessages():
         integrand.DeleteConnector(id)
         integrand.DeleteTopic(topicName)
 
-    def test_send_multiple_messaged(self):
+    def test_send_multiple_messages(self):
         id = get_random_string(5)
         topicName = get_random_string(5)
         integrand = Integrand(INTEGRAND_URL, INTEGRAND_API_KEY)

--- a/integrand-py/tests/test_integrand.py
+++ b/integrand-py/tests/test_integrand.py
@@ -146,7 +146,7 @@ class TestMessages():
         createResponse = integrand.CreateConnector(id, topicName)
         data = {'hello': 'world'}
         res = integrand.EndpointRequest(id, createResponse['data']['securityKey'], data)
-        assert res['status'] == 'success'
+        assert res['message'] == 'message sent successfully'
         response = integrand.GetEventsFromTopic(topicName, 0, 1)
         print(response)
         assert len(response['data']) == 1
@@ -166,7 +166,7 @@ class TestMessages():
             messages.append({'key'+ str(i): 'value'+ str(i)})
         for msg in messages:
             res = integrand.EndpointRequest(id, createResponse['data']['securityKey'], msg)
-            assert res['status'] == 'success'
+            assert res['message'] == 'message sent successfully'
         response = integrand.GetEventsFromTopic(topicName, 0, 5)
         assert len(response['data']) == len(messages)
         for ind, data in enumerate(messages):

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"integrand/persistence"
-	"integrand/services"
 	"integrand/utils"
 	"integrand/web"
 	"log"
@@ -24,7 +23,7 @@ func main() {
 	persistence.Initialize()
 
 	// Enable our Workflower
-	go services.Workflower()
+	//go services.Workflower()
 
 	router := web.NewNewWebRouter()
 	port := ":8000"

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"integrand/persistence"
+	"integrand/services"
 	"integrand/utils"
 	"integrand/web"
 	"log"
@@ -21,6 +22,10 @@ func main() {
 	// to change the flags on the default logger
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	persistence.Initialize()
+
+	// Enable our Workflower
+	go services.Workflower()
+
 	router := web.NewNewWebRouter()
 	port := ":8000"
 	slog.Info(fmt.Sprintf("Server started on http//:localhost%s\n", port))

--- a/services/endpoint.go
+++ b/services/endpoint.go
@@ -26,7 +26,7 @@ func GetEndpoints(userId int) ([]persistence.Endpoint, error) {
 	return persistence.DATASTORE.GetAllEndpoints(userId)
 }
 
-func GetEndpoint(userId int, EndpointID string) (persistence.Endpoint, error) {
+func GetEndpoint(EndpointID string, userId int) (persistence.Endpoint, error) {
 	return persistence.DATASTORE.GetEndpointByUser(EndpointID, userId)
 }
 

--- a/services/workflow.go
+++ b/services/workflow.go
@@ -95,7 +95,6 @@ func GetOrDefaultInt(m map[string]int, key string, defaultInt int) int {
 func sendLeadToClf(jsonBody map[string]interface{}) error {
 	defaultStr := ""
 	sinkUrl := os.Getenv("SINK_URL")
-	// sinkUrl := configuration.SINK_URL
 
 	leadCaseTypeStr := GetOrDefaultString(jsonBody, "LeadCaseType", "")
 

--- a/services/workflow.go
+++ b/services/workflow.go
@@ -22,6 +22,7 @@ type Workflow struct {
 	TopicName    string
 	Offset       int
 	FunctionName string
+	Enabled      bool
 }
 
 type funcMap map[string]interface{}
@@ -45,7 +46,6 @@ func (workflow Workflow) Call(params ...interface{}) (result interface{}, err er
 	for k, param := range params {
 		in[k] = reflect.ValueOf(param)
 	}
-	// var res []reflect.Value
 	res := f.Call(in)
 	result = res[0].Interface()
 	return

--- a/services/workflowService.go
+++ b/services/workflowService.go
@@ -11,10 +11,14 @@ const MULTIPLYER int = 2
 const MAX_BACKOFF int = 10
 
 func Workflower() error {
+	// Wait 5 seconds so we don't run into any race conditions
+	time.Sleep(5 * time.Second)
+
 	workflow := Workflow{
 		TopicName:    "test",
 		Offset:       0,
 		FunctionName: "ld_ld_sync",
+		Enabled:      true,
 	}
 
 	sleep_time := SLEEP_TIME

--- a/test-request.txt
+++ b/test-request.txt
@@ -3,7 +3,7 @@
 curl --header "Content-Type: application/json" \
   --request POST \
   --data '{"username":"hello said","password":"this is a super long string where another thing is going to happen"}' \
-  'http://localhost:8000/api/v1/connector/f/myEndpoint?apikey=rZHLiUMb
+  'http://localhost:8000/api/v1/connector/f/my?apikey=ByAXhsNb
 
 // Connector API
 // Get all Glue handler

--- a/web/appPages.go
+++ b/web/appPages.go
@@ -51,7 +51,7 @@ func LoginPage(w http.ResponseWriter, r *http.Request) {
 		}
 		tmpl.Execute(w, nil)
 	default:
-		notFoundApiError(w)
+		apiMessageResponse(w, http.StatusNotFound, "not found")
 	}
 }
 
@@ -62,14 +62,14 @@ func applicationPage(w http.ResponseWriter, r *http.Request) {
 		fileContents, err := os.ReadFile("web/templates/baseApp.html")
 		if err != nil {
 			slog.Error(err.Error())
-			internalServerError(w)
+			apiMessageResponse(w, http.StatusInternalServerError, "internal server error")
 			return
 		}
 		templateString := strings.Replace(string(fileContents), "#replace_me#", "{{ template \"application.html\" }}", 1)
 		tmpl, err := template.New("myTemplate").Parse(templateString)
 		if err != nil {
 			slog.Error(err.Error())
-			internalServerError(w)
+			apiMessageResponse(w, http.StatusInternalServerError, "internal server error")
 			return
 		}
 		_, err = tmpl.ParseFiles(
@@ -78,16 +78,16 @@ func applicationPage(w http.ResponseWriter, r *http.Request) {
 		)
 		if err != nil {
 			slog.Error(err.Error())
-			internalServerError(w)
+			apiMessageResponse(w, http.StatusInternalServerError, "internal server error")
 			return
 		}
 		err = tmpl.Execute(w, nil)
 		if err != nil {
 			log.Println(err)
-			internalServerError(w)
+			apiMessageResponse(w, http.StatusInternalServerError, "internal server error")
 			return
 		}
 	default:
-		notFoundApiError(w)
+		apiMessageResponse(w, http.StatusNotFound, "not found")
 	}
 }

--- a/web/router.go
+++ b/web/router.go
@@ -59,22 +59,20 @@ func sessionAuthenticateOrRedirect(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func internalServerError(w http.ResponseWriter) {
-	resBytes, _ := generateErrorMessage("internal server error")
-	w.WriteHeader(http.StatusInternalServerError)
-	w.Write(resBytes)
-}
-
-func notFoundApiError(w http.ResponseWriter) {
-	c := map[string]interface{}{"api": "not found"}
-	resBytes, _ := generateFailMessage(c)
-	w.WriteHeader(http.StatusNotFound)
-	w.Write(resBytes)
-}
-
 func enableCors(w *http.ResponseWriter) {
 	(*w).Header().Set("Access-Control-Allow-Origin", "*")
 	(*w).Header().Set("Access-Control-Expose-Headers", "Content-Type")
+}
+
+func apiMessageResponse(w http.ResponseWriter, errorCode int, message string) {
+	body := map[string]string{
+		"message": message,
+	}
+	// This should never error...
+	bodyBytes, _ := json.Marshal(body)
+
+	w.WriteHeader(errorCode)
+	w.Write(bodyBytes)
 }
 
 // Apis will be formatted using the "jsend" spec
@@ -89,32 +87,6 @@ func generateSuccessMessage(data interface{}) ([]byte, error) {
 	res := apiResponse{
 		Status: "success",
 		Data:   data,
-	}
-	resBytes, err := json.Marshal(res)
-	if err != nil {
-		log.Println(err)
-		return resBytes, err
-	}
-	return resBytes, nil
-}
-
-func generateFailMessage(data interface{}) ([]byte, error) {
-	res := apiResponse{
-		Status: "fail",
-		Data:   data,
-	}
-	resBytes, err := json.Marshal(res)
-	if err != nil {
-		log.Println(err)
-		return resBytes, err
-	}
-	return resBytes, nil
-}
-
-func generateErrorMessage(message string) ([]byte, error) {
-	res := apiResponse{
-		Status:  "error",
-		Message: message,
 	}
 	resBytes, err := json.Marshal(res)
 	if err != nil {

--- a/web/router.go
+++ b/web/router.go
@@ -28,7 +28,6 @@ func NewNewWebRouter() *http.ServeMux {
 	keyApi := &keyAPI{}
 	mux.Handle("/api/v1/apikey", keyApi)
 	mux.Handle("/api/v1/apikey/", keyApi)
-	mux.Handle("/api/v1/apikeys", keyApi)
 
 	// Serve static files from the "static" directory.
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("web/static"))))

--- a/web/router.go
+++ b/web/router.go
@@ -33,7 +33,6 @@ func NewNewWebRouter() *http.ServeMux {
 	// Serve static files from the "static" directory.
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("web/static"))))
 
-	go services.Workflower()
 	return mux
 }
 


### PR DESCRIPTION
- Updated response bodies of failed/errors to be
```json
"message": "my_message"
```

This is the first part in removing the `jsend` api spec