### PR TITLE
Calendly Integration Workflow Added

### DIFF
--- a/integrand-py/tests/test_integrand.py
+++ b/integrand-py/tests/test_integrand.py
@@ -179,7 +179,7 @@ class TestMessages():
 
 
 class TestsWorkflow():
-    @pytest.fixture(params=["ld_ld_sync"])
+    @pytest.fixture(params=["ld_ld_sync", "calendly_sync"])
     def functionName(self, request):
         return request.param
     

--- a/integrand-py/tests/workflow_functions/calendly_sync/message.json
+++ b/integrand-py/tests/workflow_functions/calendly_sync/message.json
@@ -1,0 +1,67 @@
+{
+  "created_at": "2024-08-05T21:58:18.000000Z",
+  "created_by": "https://api.calendly.com/users/test",
+  "event": "invitee.created",
+  "payload": {
+    "cancel_url": "https://calendly.com/cancellations/another-test",
+    "created_at": "2024-08-05T21:58:17.901807Z",
+    "email": "client_email@gmail.com",
+    "event": "https://api.calendly.com/scheduled_events/test-event",
+    "first_name": null,
+    "invitee_scheduled_by": null,
+    "last_name": null,
+    "name": "Client Name",
+    "new_invitee": null,
+    "no_show": null,
+    "old_invitee": null,
+    "payment": null,
+    "questions_and_answers": [],
+    "reconfirmation": null,
+    "reschedule_url": "https://calendly.com/reschedulings/another-test",
+    "rescheduled": false,
+    "routing_form_submission": null,
+    "scheduled_event": {
+      "created_at": "2024-08-05T21:58:17.881846Z",
+      "end_time": "2024-08-16T15:45:00.000000Z",
+      "event_guests": [],
+      "event_memberships": [
+        {
+          "user": "https://api.calendly.com/users/test",
+          "user_email": "info@testcompany.com",
+          "user_name": "Test Company"
+        }
+      ],
+      "event_type": "https://api.calendly.com/event_types/test-type",
+      "invitees_counter": {
+        "active": 1,
+        "limit": 1,
+        "total": 1
+      },
+      "location": {
+        "location": "+1 322-999-1323",
+        "type": "outbound_call"
+      },
+      "meeting_notes_html": null,
+      "meeting_notes_plain": null,
+      "name": "15 Minute Consultation",
+      "start_time": "2024-08-16T15:30:00.000000Z",
+      "status": "active",
+      "updated_at": "2024-08-05T21:58:17.881846Z",
+      "uri": "https://api.calendly.com/scheduled_events/test-event"
+    },
+    "scheduling_method": null,
+    "status": "active",
+    "text_reminder_number": null,
+    "timezone": "America/Los_Angeles",
+    "tracking": {
+      "salesforce_uuid": null,
+      "utm_campaign": null,
+      "utm_content": null,
+      "utm_medium": null,
+      "utm_source": null,
+      "utm_term": null
+    },
+    "updated_at": "2024-08-05T21:58:17.901807Z",
+    "uri": "https://api.calendly.com/scheduled_events/test-event/invitees/another-test"
+  }
+}

--- a/integrand-py/tests/workflow_functions/calendly_sync/message_output.json
+++ b/integrand-py/tests/workflow_functions/calendly_sync/message_output.json
@@ -1,0 +1,7 @@
+{
+    "Email": "client_email@gmail.com",
+    "First": "Client",
+    "Last": "Name",
+    "Phone": "+1 322-999-1323",
+    "Summary": ""
+  }

--- a/persistence/workflow.go
+++ b/persistence/workflow.go
@@ -151,5 +151,24 @@ func (dstore *Datastore) UpdateWorkflow(id int) (Workflow, error) {
 	if err != nil {
 		return workflow, err
 	}
-	return workflow, err
+	return workflow, nil
+}
+
+func (dstore *Datastore) SetOffsetOfWorkflow(id int, offset int) (Workflow, error) {
+	updateQuery := `
+		UPDATE workflows
+		SET offset = ?, last_modified = CURRENT_TIMESTAMP
+		WHERE id = ?
+		RETURNING id, topic_name, offset, function_name, enabled, sink_url, last_modified;
+	`
+
+	dstore.RWMutex.Lock()
+	row := dstore.db.QueryRow(updateQuery, offset, id)
+	dstore.RWMutex.Unlock()
+	var workflow Workflow
+	err := row.Scan(&workflow.Id, &workflow.TopicName, &workflow.Offset, &workflow.FunctionName, &workflow.Enabled, &workflow.SinkURL, &workflow.LastModified)
+	if err != nil {
+		return workflow, err
+	}
+	return workflow, nil
 }

--- a/services/workflow.go
+++ b/services/workflow.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -19,7 +20,8 @@ const MAX_BACKOFF int = 10
 func init() {
 	// Register all of our functions
 	persistence.FUNC_MAP = map[string]interface{}{
-		"ld_ld_sync": ld_ld_sync,
+		"ld_ld_sync":    ld_ld_sync,
+		"calendly_sync": calendly_sync,
 	}
 }
 
@@ -45,10 +47,10 @@ func processWorkflow(wg *sync.WaitGroup, workflow persistence.Workflow) {
 		bytes, err := persistence.BROKER.ConsumeMessage(workflow.TopicName, workflow.Offset)
 		if err != nil {
 			if err.Error() == "offset out of bounds" {
-				// This error is returned when we're given an offset thats ahead of the commitlog
+				// This error is returned when we're given an offset thats ahead of the commitlog, so we can return for next cycle to begin
 				slog.Debug(err.Error())
 				time.Sleep(time.Duration(sleep_time) * time.Second)
-				continue
+				return
 			} else if err.Error() == "offset does not exist" {
 				// This error is returned when we look for an offset and it does not exist becuase it can't be avaliable in the commitlog
 				slog.Warn(err.Error())
@@ -109,6 +111,105 @@ func sendLeadToClf(jsonBody map[string]interface{}, sinkURL string) error {
 	}
 
 	jsonBodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		slog.Error(err.Error())
+		return err
+	}
+
+	resp, err := http.Post(sinkURL, "application/json", bytes.NewBuffer(jsonBodyBytes))
+	if err != nil {
+		slog.Error(err.Error())
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Error("HTTP request failed",
+			"status_code", resp.StatusCode,
+			"status_text", http.StatusText(resp.StatusCode),
+		)
+		return errors.New("HTTP request failed with status code: " + http.StatusText(resp.StatusCode))
+	}
+
+	var responseBody map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&responseBody); err != nil {
+		slog.Error(err.Error())
+		return err
+	}
+
+	log.Printf("Status Code: %d", resp.StatusCode)
+	log.Printf("Response Body: %v", responseBody)
+	return nil
+}
+
+type CalendlyEventBody struct {
+	Event   string  `json:"event"`
+	Payload Payload `json:"payload"`
+}
+
+type Payload struct {
+	FirstName      *string `json:"first_name"`
+	LastName       *string `json:"last_name"`
+	Name           string  `json:"name"`
+	Email          string  `json:"email"`
+	ScheduledEvent struct {
+		Location struct {
+			Location *string `json:"location"`
+			Type     *string `json:"type"`
+		} `json:"location"`
+	} `json:"scheduled_event"`
+}
+
+type CalendlyRequest struct {
+	First   string `json:"First"`
+	Last    string `json:"Last"`
+	Phone   string `json:"Phone"`
+	Email   string `json:"Email"`
+	Summary string `json:"Summary"`
+}
+
+func calendly_sync(bytes []byte, sinkURL string) error {
+	// Unmarshal the JSON byte array into the map
+	var calendlyJson CalendlyEventBody
+	err := json.Unmarshal(bytes, &calendlyJson)
+	if err != nil {
+		slog.Error(err.Error())
+		return err
+	}
+
+	if calendlyJson.Event == "invitee.created" {
+		err := sendCalendlyAppointment(calendlyJson, sinkURL)
+		if err != nil {
+			slog.Error("Error occurred while sending calendly appointment to CLF", "error", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func sendCalendlyAppointment(calendlyJson CalendlyEventBody, sinkURL string) error {
+	payload := calendlyJson.Payload
+	var request CalendlyRequest
+
+	if payload.FirstName != nil {
+		request.First = *payload.FirstName
+		request.Last = *payload.LastName
+	} else {
+		nameParts := strings.Split(strings.TrimSpace(payload.Name), " ")
+		request.First = nameParts[0]
+		if len(nameParts) > 1 {
+			request.Last = nameParts[1]
+		}
+	}
+
+	if *payload.ScheduledEvent.Location.Type == "outbound_call" {
+		request.Phone = *payload.ScheduledEvent.Location.Location
+	}
+
+	request.Email = payload.Email
+
+	jsonBodyBytes, err := json.Marshal(request)
 	if err != nil {
 		slog.Error(err.Error())
 		return err


### PR DESCRIPTION
Right now,

- I only process the incoming data of a created appointment. There are some messages with updates or cancellation but they don't change the info we're transforming into, so I decided to just pass those messages. 
- I try to parse first name and last name, if can't be parsed I set it to an empty string.
- I set phone number if it's an outbound call, otherwise empty string.
- I set summary to an empty string.

Naming of the functions may be iffy.

Bugfix:

- Also, after migrating to the database, I've forgot to change how workflow's offset is set, so it wasn't setting properly.

Potential issue, ran into it while trying to find bugs:

- Also, a workflow is useless without a topic, right? 
We should create a foreign key for it so that updates or deletions of the topic are cascaded to the workflow. To achieve this, we either need to duplicate the topic name or backpopulate it. Alternatively, a faster solution would be to catch an "ERROR topic not found" message when processing a workflow. If we encounter this error, we can delete the workflow.